### PR TITLE
fixed chat template for Qwen and gemma models in make_prompt; fixed d…

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,9 +8,23 @@ class ModelConfig:
     MODEL_CONFIG_THINK_TOKENS = {
         "begin_think": "<think>",
         "end_think": "</think>",
+        "generate_kwargs": {
+            "repetition_penalty": 1.2,
+            "temperature": 0.7,
+            "top_k": 20,
+            "min_p": 0.0,
+            "top_p": 0.95,
+        },
     }
     MODEL_CONFIG_FUZZY_ANSWER = {
         "fuzzy_end_think_list": ["Answer: ", "Final Answer: ", "The answer is: ", "Solution: "],
+        "generate_kwargs": {
+            "repetition_penalty": 1.2,
+            "temperature": 0.7,
+            "top_k": 20,
+            "min_p": 0.0,
+            "top_p": 0.95,
+        },
     }
     DEFAULT_MODEL_CONFIG = MODEL_CONFIG_FUZZY_ANSWER
 

--- a/src/config.py
+++ b/src/config.py
@@ -10,8 +10,7 @@ class ModelConfig:
         "end_think": "</think>",
     }
     MODEL_CONFIG_FUZZY_ANSWER = {
-        "begin_think_fuzzy": "model",
-        "end_think_fuzzy": ["Answer: ", "Final Answer: ", "The answer is: ", "Solution: ", "return "],
+        "fuzzy_end_think_list": ["Answer: ", "Final Answer: ", "The answer is: ", "Solution: "],
     }
     DEFAULT_MODEL_CONFIG = MODEL_CONFIG_FUZZY_ANSWER
 

--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,8 @@ class ModelConfig:
         "end_think": "</think>",
     }
     MODEL_CONFIG_FUZZY_ANSWER = {
-        "fuzzy_separator": "Answer: ",
+        "begin_think_fuzzy": "model",
+        "end_think_fuzzy": ["Answer: ", "Final Answer: ", "The answer is: ", "Solution: ", "return "],
     }
     DEFAULT_MODEL_CONFIG = MODEL_CONFIG_FUZZY_ANSWER
 

--- a/src/model.py
+++ b/src/model.py
@@ -154,20 +154,18 @@ class CoTModel(Model):
         """Generate a response using Chain-of-Thought (CoT) prompting."""
         model_config = ModelConfig.get(self.model_name)
 
+        generate_kwargs = model_config.get("generate_kwargs")
+
         inputs = self.tokenizer(prompt, return_tensors="pt").to(self.model.device)
         output = self.model.generate(
             **inputs,
             max_new_tokens=max_new_tokens,
             do_sample=True,
-            repetition_penalty=1.2,
-            temperature=0.7,
-            top_k=20,
-            min_p=0.0,
-            top_p=0.95,
             eos_token_id=self.tokenizer.eos_token_id,
             pad_token_id=self.tokenizer.eos_token_id,
             output_scores=True,
             return_dict_in_generate=True,
+            **generate_kwargs,
         )
         return output
 

--- a/src/model.py
+++ b/src/model.py
@@ -43,33 +43,51 @@ ModelResponse(
         print(f"Answer: {self._encode(self.answer)}")
         print("\n")
 
-
 class Model:
-    MODEL_CONFIG_QWEN = {
-        "begin_think": "<think>",
-        "end_think": "</think>",
-    }
-
-    MODEL_CONFIG_WLA = {
-        "begin_think_fuzzy": "model",
-        "end_think_fuzzy": ["Answer: ", "Final Answer: ", "The answer is: ", "Solution: ", "return "],
-    }
-
-    SUPPORTED_MODELS = {
-        "Qwen/Qwen3-0.6B": MODEL_CONFIG_QWEN,
-        "Qwen/Qwen3-1.7B": MODEL_CONFIG_QWEN,
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": MODEL_CONFIG_QWEN,
-        #"deepcogito/cogito-v1-preview-llama-3B": MODEL_CONFIG_QWEN,  # unverified
-        "Wladastic/Mini-Think-Base-1B": MODEL_CONFIG_WLA,
-        "google/gemma-2-2b": MODEL_CONFIG_WLA,
-        #"microsoft/phi-2": MODEL_CONFIG_WLA,  # not very consistent
-    }
-
     def __init__(self, model_name: str, cache_dir="/tmp/cache"):
-        if model_name not in self.SUPPORTED_MODELS:
-            print(f"ERROR: model {model_name} is not in supported list {self.SUPPORTED_MODELS}")
+        self.model_name = model_name
+        self.cache_dir = cache_dir
+
+    def get_utils(self):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def make_prompt(self, question_id, question, custom_instruction="Let's think step by step."):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def do_generate(self, question_id, prompt, max_new_tokens=4096):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def generate_cot_response(self, question_id, question, max_new_tokens=4096):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def evaluate_cot_response(self, question_id, prompt, max_new_tokens=4096):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def evaluate_cot_response_from_tokens(self, question_id, prompt_tokens: torch.Tensor, max_new_tokens=4096):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def get_log_probs(self, sequences: torch.Tensor):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def do_split(self, sequences):
+        raise NotImplementedError("Subclasses must implement this method")
+
+class CoTModel:
+    def __init__(self, model_name: str, cache_dir="/tmp/cache"):
+        super().__init__(model_name, cache_dir)
+
+        if not ModelConfig.is_supported(model_name):
+            print(f"ERROR: model {model_name} is not in supported list {ModelConfig.SUPPORTED_MODELS}")
             exit(1)
 
+        try:
+            (self.tokenizer, self.model) = self._load_model(model_name, cache_dir)
+            self.utils = TokenUtils(self.model, self.tokenizer)
+        except Exception as e:
+            print(f"Error loading model {model_name}: {e}")
+            raise
+
+    def _load_model(self, model_name, cache_dir):
         self.model_name = model_name
         
         config = AutoConfig.from_pretrained(
@@ -78,30 +96,28 @@ class Model:
             trust_remote_code=True,
         )
 
-        try:
-            self.tokenizer = AutoTokenizer.from_pretrained(
-                model_name,
-                cache_dir=cache_dir,
-            )
-            self.model = AutoModelForCausalLM.from_pretrained(
-                model_name,
-                config=config,
-                torch_dtype=torch.float16,
-                device_map="auto",
-                cache_dir=cache_dir,
-            )
-            self.utils = TokenUtils(self.model, self.tokenizer)
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name,
+            cache_dir=cache_dir,
+        )
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            config=config,
+            torch_dtype=torch.float16,
+            device_map="auto",
+            cache_dir=cache_dir,
+        )
+        return (tokenizer, model)
 
-        except Exception as e:
-            print(f"Error loading model {model_name}: {e}")
-            raise
+    def get_utils(self):
+        return self.utils
 
     def generate_cot_response(self, question_id, question, max_new_tokens=4096):
         final_response = self.generate_cot_response_full(question_id, question, max_new_tokens)
         return final_response.basic_pair
 
     def make_prompt(self, question_id, question, custom_instruction="Let's think step by step."):
-        model_config = self.SUPPORTED_MODELS[self.model_name]
+        model_config = ModelConfig.get(self.model_name)
         history = [
             {"role": "user", "content": f"Question: {question}\n{custom_instruction}"},
         ]
@@ -136,7 +152,7 @@ class Model:
 
     def do_generate(self, question_id, prompt, max_new_tokens=4096):
         """Generate a response using Chain-of-Thought (CoT) prompting."""
-        model_config = self.SUPPORTED_MODELS[self.model_name]
+        model_config = ModelConfig.get(self.model_name)
 
         inputs = self.tokenizer(prompt, return_tensors="pt").to(self.model.device)
         output = self.model.generate(
@@ -162,7 +178,7 @@ class Model:
         return log_probs
 
     def do_split(self, sequences):
-        model_config = self.SUPPORTED_MODELS[self.model_name]
+        model_config = ModelConfig.get(self.model_name)
 
         # should split the output into three parts: question, the chain of thought and the answer
         if("begin_think" in model_config):
@@ -299,7 +315,7 @@ class Model:
         return token_id
 
     def get_think_tokens(self):
-        model_config = self.SUPPORTED_MODELS[self.model_name]
+        model_config = ModelConfig.get(self.model_name)
 
         begin_think = self._get_token_id(model_config["begin_think"])
         end_think = self._get_token_id(model_config["end_think"])

--- a/src/model.py
+++ b/src/model.py
@@ -4,6 +4,7 @@ import torch
 from dataclasses import dataclass
 from token_utils import TokenUtils
 from typing import Optional
+from config import ModelConfig
 
 @dataclass
 class ModelResponse:

--- a/src/model.py
+++ b/src/model.py
@@ -73,7 +73,7 @@ class Model:
     def do_split(self, sequences):
         raise NotImplementedError("Subclasses must implement this method")
 
-class CoTModel:
+class CoTModel(Model):
     def __init__(self, model_name: str, cache_dir="/tmp/cache"):
         super().__init__(model_name, cache_dir)
 
@@ -89,8 +89,6 @@ class CoTModel:
             raise
 
     def _load_model(self, model_name, cache_dir):
-        self.model_name = model_name
-        
         config = AutoConfig.from_pretrained(
             model_name,
             cache_dir=cache_dir,


### PR DESCRIPTION
1. Improved handling of chat templates in make_prompt for the Qwen and Gemma models, ensuring that prompts are formatted correctly for both models.
2. Updated do_split to better accommodate the Gemma model, allowing it to return up to three pieces. Notably, since output from Gemma 2b can sometimes lack a clear transition form CoT to the final answer, the function now permits the CoT and Answer segments to be identical when failing to locate the fuzzy separator.