### PR TITLE
added new model org files!

### DIFF
--- a/src/finetune/ft_for_stego.py
+++ b/src/finetune/ft_for_stego.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+
+import os, re, json, importlib.util, logging
+from dataclasses import dataclass
+from typing import List, Dict, Optional, Tuple
+
+if "MPLCONFIGDIR" not in os.environ:
+    try:
+        _mpl_dir = os.path.join(os.getcwd(), ".mplconfig")
+        os.makedirs(_mpl_dir, exist_ok=True)
+        os.environ["MPLCONFIGDIR"] = _mpl_dir
+    except Exception:
+        pass
+
+import torch
+from torch.utils.data import Dataset
+
+# Safe import of HF modules
+def _maybe_stub_peft(use_lora: bool):
+    if use_lora:
+        return  # -> real peft
+
+    import sys, types
+    if "peft" in sys.modules:
+        return  # already imported
+
+    peft_stub = types.ModuleType("peft")
+    class PeftModel:
+        pass
+    peft_stub.PeftModel = PeftModel
+    peft_stub.__all__ = ["PeftModel"]
+    sys.modules["peft"] = peft_stub
+
+def import_tf_modules(use_lora: bool):
+    _maybe_stub_peft(use_lora)
+    from transformers import (
+        AutoConfig,
+        AutoTokenizer,
+        BitsAndBytesConfig,
+        Trainer,
+        TrainingArguments,
+        set_seed,
+        EarlyStoppingCallback,
+        AutoModelForCausalLM,
+    )
+    import transformers
+    return transformers, AutoConfig, AutoTokenizer, BitsAndBytesConfig, Trainer, TrainingArguments, set_seed, EarlyStoppingCallback, AutoModelForCausalLM
+
+# Data utils
+def setup_logger(log_level: str = "INFO"):
+    level = getattr(logging, log_level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+def load_jsonl(path: str) -> List[Dict]:
+    rows = []
+    with open(path, "r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line: 
+                continue
+            try:
+                rows.append(json.loads(line))
+            except Exception as e:
+                raise ValueError(f"Invalid JSON at line {i} in {path}: {e}")
+    return rows
+
+@dataclass
+class DataRow:
+    messages: List[Dict[str, str]]
+
+class ChatJsonlDataset(Dataset):
+    def __init__(self, rows: List[Dict], tokenizer, mask_mode: str = "cot_and_answer",
+                 max_length: int = 2048, allow_truncation: bool = True,
+                 answer_prefix: str = r"Answer\s*:\s*", supervise_think_inner: bool = True):
+        self.rows = [DataRow(messages=row["messages"]) for row in rows]
+        if not self.rows:
+            raise ValueError("Empty dataset.")
+        self.tok = tokenizer
+        self.mask_mode = mask_mode
+        self.max_length = max_length
+        self.allow_truncation = allow_truncation
+        self.answer_prefix = answer_prefix
+        self.supervise_think_inner = supervise_think_inner
+        if self.rows[0].messages[-1].get("role") != "assistant":
+            raise ValueError("Each example must end with an 'assistant' message.")
+
+    def __len__(self): return len(self.rows)
+
+    def _render_prompt_and_target(self, messages: List[Dict[str, str]]):
+        msgs = [{"role": m["role"], "content": m["content"]} for m in messages]
+        if msgs[-1]["role"] != "assistant":
+            raise ValueError("Last message must be 'assistant'.")
+        # prefer chat template
+        try:
+            prompt_msgs = msgs[:-1] + [{"role": "assistant", "content": ""}]
+            prompt_text = self.tok.apply_chat_template(
+                prompt_msgs, tokenize=False, add_generation_prompt=True
+            )
+        except Exception:
+            # fallback join
+            parts = []
+            for m in msgs[:-1]:
+                parts.append(f"{m['role'].upper()}: {m['content']}")
+            parts.append("ASSISTANT:")
+            prompt_text = "\n".join(parts)
+        assistant_text = msgs[-1]["content"]
+        return prompt_text, assistant_text
+
+    def _mask_labels(self, prompt_ids, full_ids, assistant_text: str):
+        labels = full_ids.clone()
+        labels[:, :prompt_ids.shape[1]] = -100
+        if self.mask_mode == "assistant":
+            return labels
+        asst_ids = self.tok(assistant_text, return_tensors="pt", add_special_tokens=False).input_ids
+        start = prompt_ids.shape[1]
+        end = start + asst_ids.shape[1]
+        labels[:, start:end] = -100
+
+        def token_span_from_char_span(c0, c1):
+            prefix_ids = self.tok(assistant_text[:c0], return_tensors="pt", add_special_tokens=False).input_ids
+            span_ids = self.tok(assistant_text[c0:c1], return_tensors="pt", add_special_tokens=False).input_ids
+            return start + prefix_ids.shape[1], start + prefix_ids.shape[1] + span_ids.shape[1]
+
+        spans = []
+        if self.mask_mode in {"cot", "cot_and_answer"}:
+            pat = r"<think>(.*?)</think>" if self.supervise_think_inner else r"(<think>.*?</think>)"
+            m = re.search(pat, assistant_text, flags=re.DOTALL | re.IGNORECASE)
+            if m:
+                c0, c1 = (m.span(1))
+                spans.append(token_span_from_char_span(c0, c1))
+        if self.mask_mode in {"answer_only", "cot_and_answer"}:
+            m = re.search(rf"({self.answer_prefix}.*)$", assistant_text, flags=re.IGNORECASE | re.DOTALL)
+            if m:
+                c0, c1 = m.span(1)
+                spans.append(token_span_from_char_span(c0, c1))
+            else:
+                # fallback to last non-empty line
+                for line in reversed(assistant_text.splitlines()):
+                    if line.strip():
+                        last = line
+                        c0 = assistant_text.rfind(last); c1 = c0 + len(last)
+                        spans.append(token_span_from_char_span(c0, c1))
+                        break
+        if not spans and self.mask_mode != "answer_only":
+            spans.append((start, end))
+        for t0, t1 in spans:
+            labels[:, t0:t1] = full_ids[:, t0:t1]
+        return labels
+
+    def __getitem__(self, idx: int):
+        row = self.rows[idx]
+        prompt_text, assistant_text = self._render_prompt_and_target(row.messages)
+        prompt_enc = self.tok(prompt_text, return_tensors="pt", add_special_tokens=False)
+        full_text = prompt_text + assistant_text
+        full_enc = self.tok(full_text, return_tensors="pt", add_special_tokens=False)
+        input_ids = full_enc.input_ids
+        attention_mask = full_enc.attention_mask
+        if input_ids.shape[1] > self.max_length:
+            if not self.allow_truncation:
+                raise ValueError(f"Example length {input_ids.shape[1]} exceeds max_length {self.max_length}")
+            input_ids = input_ids[:, -self.max_length:]
+            attention_mask = attention_mask[:, -self.max_length:]
+            prompt_enc2 = self.tok(prompt_text, return_tensors="pt", add_special_tokens=False)
+            if prompt_enc2.input_ids.shape[1] >= input_ids.shape[1]:
+                prompt_ids = input_ids.clone(); prompt_ids[:] = 0
+            else:
+                prompt_ids = prompt_enc2.input_ids
+        else:
+            prompt_ids = prompt_enc.input_ids
+        labels = self._mask_labels(prompt_ids, input_ids, assistant_text)
+        return {"input_ids": input_ids.squeeze(0),
+                "attention_mask": attention_mask.squeeze(0),
+                "labels": labels.squeeze(0)}
+
+# fallback loader
+def _import_module_from_path(module_name: str, file_path: str):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+def _normalize_automap_entry(entry):
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, list) and entry:
+        return entry[0]
+    if isinstance(entry, dict):
+        for v in entry.values():
+            if isinstance(v, str):
+                return v
+            if isinstance(v, list) and v:
+                return v[0]
+    raise ValueError(f"Unsupported auto_map entry format: {entry!r}")
+
+def load_model_with_fallbacks(model_id: str, cache_dir: Optional[str], torch_dtype=None,
+                              quantization_config=None, device_map="auto", AutoConfig=None, AutoModelForCausalLM=None):
+    """
+    initially- Try normal Auto* with trust_remote_code=True
+    if it fails because arch is unknown to your Transformers, try to load via repo auto_map
+    """
+    import logging
+    try:
+        from huggingface_hub import hf_hub_download
+    except Exception as e:
+        hf_hub_download = None
+
+    # Normal path
+    try:
+        cfg = AutoConfig.from_pretrained(model_id, cache_dir=cache_dir, trust_remote_code=True)
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id, config=cfg, cache_dir=cache_dir, trust_remote_code=True,
+            quantization_config=quantization_config, torch_dtype=torch_dtype, device_map=device_map,
+        )
+        return model
+    except Exception as e:
+        logging.warning(f"Auto load failed: {e}")
+
+    # remote code via auto_map (only if can read config.json)
+    if hf_hub_download is not None:
+        cfg_path = hf_hub_download(repo_id=model_id, filename="config.json", cache_dir=cache_dir)
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg_json = json.load(f)
+        auto_map = cfg_json.get("auto_map", {})
+        if not auto_map:
+            raise RuntimeError(
+                "Could not load the model. Your Transformers version likely doesn't support this architecture, "
+                "and the repo does not expose remote code via auto_map. Please upgrade transformers on your path "
+                "(e.g., pip install -U transformers) or pick a model repo that provides remote code."
+            )
+        model_map = _normalize_automap_entry(auto_map.get("AutoModelForCausalLM"))
+        config_map = _normalize_automap_entry(auto_map.get("AutoConfig"))
+        model_py = model_map.split(".")[0] + ".py"
+        config_py = config_map.split(".")[0] + ".py"
+        model_file = hf_hub_download(repo_id=model_id, filename=model_py, cache_dir=cache_dir)
+        config_file = hf_hub_download(repo_id=model_id, filename=config_py, cache_dir=cache_dir)
+        model_module = _import_module_from_path("remote_modeling", model_file)
+        config_module = _import_module_from_path("remote_configuration", config_file)
+        ModelClass = getattr(model_module, model_map.split(".")[-1])
+        ConfigClass = getattr(config_module, config_map.split(".")[-1])
+        try:
+            remote_cfg = ConfigClass.from_pretrained(model_id, cache_dir=cache_dir)
+        except Exception:
+            remote_cfg = ConfigClass(**cfg_json)
+        model = ModelClass.from_pretrained(
+            model_id, config=remote_cfg, cache_dir=cache_dir,
+            quantization_config=quantization_config, torch_dtype=torch_dtype, device_map=device_map,
+        )
+        return model
+
+    # No huggingface_hub available at all
+    raise RuntimeError(
+        "huggingface_hub is not available, and native Auto* load failed! "
+        "Install it (pip install huggingface_hub) or upgrade transformers!"
+    )
+
+# Main
+def main():
+    import argparse, os
+    parser = argparse.ArgumentParser()
+    # data
+    parser.add_argument("--train_jsonl", required=True)
+    parser.add_argument("--val_jsonl", default=None)
+    parser.add_argument("--mask_mode", default="cot_and_answer", choices=["assistant","cot","cot_and_answer","answer_only"])
+    parser.add_argument("--max_length", type=int, default=2048)
+    parser.add_argument("--seed", type=int, default=42)
+
+    # model / training
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--cache_dir", default=None)
+
+    parser.add_argument("--use_lora", action="store_true")
+    parser.add_argument("--lora_r", type=int, default=16)
+    parser.add_argument("--lora_alpha", type=int, default=32)
+    parser.add_argument("--lora_dropout", type=float, default=0.05)
+    parser.add_argument("--lora_target_modules", default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj")
+
+    parser.add_argument("--load_in_4bit", action="store_true")
+    parser.add_argument("--load_in_8bit", action="store_true")
+    parser.add_argument("--gradient_checkpointing", action="store_true")
+    parser.add_argument("--use_flash_attention_2", action="store_true")
+
+    # trainer args
+    parser.add_argument("--per_device_train_batch_size", type=int, default=1)
+    parser.add_argument("--per_device_eval_batch_size", type=int, default=1)
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
+    parser.add_argument("--learning_rate", type=float, default=2e-5)
+    parser.add_argument("--num_train_epochs", type=float, default=1.0)
+    parser.add_argument("--weight_decay", type=float, default=0.0)
+    parser.add_argument("--warmup_ratio", type=float, default=0.03)
+    parser.add_argument("--lr_scheduler_type", default="cosine")
+
+    parser.add_argument("--save_steps", type=int, default=500)
+    parser.add_argument("--eval_steps", type=int, default=500)
+    parser.add_argument("--logging_steps", type=int, default=10)
+    parser.add_argument("--save_total_limit", type=int, default=3)
+    parser.add_argument("--save_strategy", default="steps", choices=["steps","epoch","no"])
+    parser.add_argument("--eval_strategy", default="steps", choices=["no","steps","epoch"])
+
+    parser.add_argument("--bf16", action="store_true")
+    parser.add_argument("--fp16", action="store_true")
+
+    parser.add_argument("--resume_from", default=None)
+    parser.add_argument("--delete_optim_states_after_save", action="store_true")
+
+    # early stopping
+    parser.add_argument("--use_early_stopping", action="store_true")
+    parser.add_argument("--early_stopping_patience", type=int, default=3)
+    parser.add_argument("--early_stopping_threshold", type=float, default=0.0)
+
+    # masking QoL
+    parser.add_argument("--answer_prefix_regex", default=r"Answer\s*:\s*")
+    parser.add_argument("--supervise_think_outer", action="store_true")
+
+    # logging
+    parser.add_argument("--wandb_project", default=None)
+    parser.add_argument("--run_name", default=None)
+    parser.add_argument("--log_level", default="INFO")
+
+    args = parser.parse_args()
+    setup_logger(args.log_level)
+
+    transformers, AutoConfig, AutoTokenizer, BitsAndBytesConfig, Trainer, TrainingArguments, set_seed, EarlyStoppingCallback, AutoModelForCausalLM = import_tf_modules(args.use_lora)
+    logging.info(f"PyTorch version {torch.__version__} available.")
+
+    set_seed(args.seed)
+
+    # data
+    rows_train = load_jsonl(args.train_jsonl)
+    rows_val = load_jsonl(args.val_jsonl) if args.val_jsonl else None
+    logging.info(f"Loaded {len(rows_train)} train; {0 if rows_val is None else len(rows_val)} val.")
+
+    # tokeniser
+    logging.info(f"Loading tokenizer: {args.model}")
+    tok = AutoTokenizer.from_pretrained(args.model, cache_dir=args.cache_dir, trust_remote_code=True)
+    if tok.pad_token_id is None:
+        tok.pad_token = tok.eos_token
+    try: tok.padding_side = "right"
+    except Exception: pass
+
+    # quantisation
+    quant_config = None
+    if args.load_in_4bit or args.load_in_8bit:
+        try:
+            quant_config = BitsAndBytesConfig(
+                load_in_4bit=args.load_in_4bit,
+                load_in_8bit=args.load_in_8bit,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_compute_dtype=torch.bfloat16 if args.bf16 else torch.float16,
+            )
+        except Exception as e:
+            raise RuntimeError("bitsandbytes is required for 4/8-bit. Install with `pip install bitsandbytes`.") from e
+
+    # model
+    logging.warning("If this is Qwen3 on an older Transformers, I'll try remote-code fallback next.")
+    logging.info(f"Loading model: {args.model}")
+    torch_dtype = torch.bfloat16 if args.bf16 else (torch.float16 if args.fp16 else None)
+    model = load_model_with_fallbacks(
+        model_id=args.model,
+        cache_dir=args.cache_dir,
+        torch_dtype=torch_dtype,
+        quantization_config=quant_config,
+        device_map="auto",
+        AutoConfig=AutoConfig,
+        AutoModelForCausalLM=AutoModelForCausalLM,
+    )
+
+    # optional toggles
+    if args.use_flash_attention_2:
+        try:
+            model.enable_input_require_grads()
+            model.config.use_flash_attention_2 = True
+            logging.info("Enabled FlashAttention 2.")
+        except Exception as e:
+            logging.warning(f"Failed to enable FlashAttention2: {e}")
+    if args.gradient_checkpointing:
+        try:
+            model.gradient_checkpointing_enable()
+            logging.info("Enabled gradient checkpointing.")
+        except Exception as e:
+            logging.warning(f"Failed to enable gradient checkpointing: {e}")
+
+    # LoRA - if requested
+    if args.use_lora:
+        try:
+            from peft import LoraConfig, TaskType, get_peft_model, prepare_model_for_kbit_training
+        except Exception as e:
+            raise RuntimeError("You requested --use_lora but `peft` import failed. "
+                               "Install a Python-3.12-compatible peft or use a compatible Python.") from e
+        if quant_config is not None:
+            model = prepare_model_for_kbit_training(model)
+        target_modules = [m.strip() for m in args.lora_target_modules.split(",") if m.strip()]
+        lora_cfg = LoraConfig(
+            r=args.lora_r, lora_alpha=args.lora_alpha, lora_dropout=args.lora_dropout,
+            target_modules=target_modules, task_type=TaskType.CAUSAL_LM, bias="none",
+        )
+        model = get_peft_model(model, lora_cfg)
+        try: model.print_trainable_parameters()
+        except Exception: pass
+
+    # datasets
+    ds_train = ChatJsonlDataset(rows_train, tok, mask_mode=args.mask_mode, max_length=args.max_length,
+                                answer_prefix=args.answer_prefix_regex, supervise_think_inner=not args.supervise_think_outer)
+    ds_eval = ChatJsonlDataset(rows_val, tok, mask_mode=args.mask_mode, max_length=args.max_length,
+                               answer_prefix=args.answer_prefix_regex, supervise_think_inner=not args.supervise_think_outer) if rows_val else None
+
+    # collator
+    def collate_fn(batch):
+        input_ids = [b["input_ids"] for b in batch]
+        attn = [b["attention_mask"] for b in batch]
+        labels = [b["labels"] for b in batch]
+        input_ids = torch.nn.utils.rnn.pad_sequence(input_ids, batch_first=True, padding_value=tok.pad_token_id)
+        attention_mask = torch.nn.utils.rnn.pad_sequence(attn, batch_first=True, padding_value=0)
+        labels = torch.nn.utils.rnn.pad_sequence(labels, batch_first=True, padding_value=-100)
+        return {"input_ids": input_ids, "attention_mask": attention_mask, "labels": labels}
+
+    # W&B
+    if args.wandb_project:
+        try:
+            import wandb
+            os.environ["WANDB_PROJECT"] = args.wandb_project
+            if args.run_name: os.environ["WANDB_NAME"] = args.run_name
+            wandb.init(project=args.wandb_project, name=args.run_name, config=vars(args))
+        except Exception as e:
+            logging.warning(f"W&B init failed: {e}")
+
+    # evaluation strategy
+    eval_strategy = args.eval_strategy
+    if ds_eval is None and eval_strategy != "no":
+        logging.warning("No validation set provided; switching eval_strategy to 'no'.")
+        eval_strategy = "no"
+
+    from transformers import TrainingArguments, Trainer, EarlyStoppingCallback
+    train_args = TrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        per_device_eval_batch_size=args.per_device_eval_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        learning_rate=args.learning_rate,
+        num_train_epochs=args.num_train_epochs,
+        weight_decay=args.weight_decay,
+        warmup_ratio=args.warmup_ratio,
+        lr_scheduler_type=args.lr_scheduler_type,
+        logging_steps=args.logging_steps,
+        save_steps=args.save_steps,
+        eval_steps=args.eval_steps,
+        save_total_limit=args.save_total_limit,
+        eval_strategy=eval_strategy,
+        save_strategy=args.save_strategy,
+        bf16=args.bf16, fp16=args.fp16,
+        report_to=("wandb" if args.wandb_project else "none"),
+        run_name=args.run_name,
+    )
+
+    callbacks = []
+    if args.use_early_stopping:
+        if ds_eval is None or eval_strategy == "no":
+            logging.warning("--use_early_stopping requires a validation set and eval strategy.")
+        else:
+            callbacks.append(EarlyStoppingCallback(
+                early_stopping_patience=args.early_stopping_patience,
+                early_stopping_threshold=args.early_stopping_threshold
+            ))
+
+    trainer = Trainer(
+        model=model,
+        args=train_args,
+        train_dataset=ds_train,
+        eval_dataset=ds_eval,
+        data_collator=collate_fn,
+        tokenizer=tok,
+        callbacks=callbacks,
+    )
+
+    # delete optimiser/scheduler state after save to save disk
+    if args.delete_optim_states_after_save:
+        class _Cleaner:
+            def __init__(self, out): self.out = out
+            def on_save(self):
+                from pathlib import Path
+                import os, logging
+                try:
+                    for ckpt in sorted(Path(self.out).glob("checkpoint-*")):
+                        for name in ("optimizer.pt","scheduler.pt"):
+                            p = ckpt / name
+                            if p.exists():
+                                p.unlink()
+                except Exception as e:
+                    logging.warning(f"Failed to delete optimizer/scheduler states: {e}")
+        cleaner = _Cleaner(args.output_dir)
+        orig_save = trainer._save
+        def _save_hook(output_dir=None, state_dict=None):
+            out = orig_save(output_dir, state_dict); cleaner.on_save(); return out
+        trainer._save = _save_hook  # type: ignore
+
+    logging.info("Starting training...")
+    train_result = trainer.train(resume_from_checkpoint=args.resume_from)
+    trainer.save_model(args.output_dir)
+    tok.save_pretrained(args.output_dir)
+
+    metrics = train_result.metrics
+    trainer.log_metrics("train", metrics)
+    trainer.save_metrics("train", metrics)
+    trainer.save_state()
+
+    if ds_eval is not None:
+        logging.info("Running evaluation...")
+        eval_metrics = trainer.evaluate()
+        trainer.log_metrics("eval", eval_metrics)
+        trainer.save_metrics("eval", eval_metrics)
+
+    # write history CSV
+    try:
+        hist = trainer.state.log_history
+        csv_path = os.path.join(args.output_dir, "loss_history.csv")
+        with open(csv_path, "w", encoding="utf-8") as f:
+            f.write("step,loss,eval_loss,learning_rate\n")
+            for rec in hist:
+                f.write(f"{rec.get('step','')},{rec.get('loss','')},{rec.get('eval_loss','')},{rec.get('learning_rate','')}\n")
+        logging.info(f"Wrote {csv_path}")
+    except Exception as e:
+        logging.warning(f"Failed to write loss history: {e}")
+
+    logging.info("Done.")
+
+if __name__ == "__main__":
+    main()

--- a/src/finetune/inference.py
+++ b/src/finetune/inference.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""
+python inference.py \
+    --model_name_or_path Qwen/Qwen3-0.6B \
+    --adapter_path models/ft/stego_lora_qwen06b/checkpoint-462 \
+    --question "Tim rides his bike back and forth..." \
+    --check_stego
+"""
+from __future__ import annotations
+import argparse, json, logging, os, random, re, sys, time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, StoppingCriteria, StoppingCriteriaList
+
+# Optional packages
+try:
+    from peft import PeftModel
+    _PEFT_AVAILABLE = True
+except Exception:
+    _PEFT_AVAILABLE = False
+
+try:
+    from transformers import BitsAndBytesConfig
+    _BNB_AVAILABLE = True
+except Exception:
+    _BNB_AVAILABLE = False
+
+try:
+    from datasets import load_dataset
+    _DATASETS_AVAILABLE = True
+except Exception:
+    _DATASETS_AVAILABLE = False
+
+
+# Logging / utils
+def setup_logging(log_level: str, log_file: Path):
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    handlers = [logging.StreamHandler(sys.stdout), logging.FileHandler(log_file, encoding="utf-8")]
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.INFO),
+        format="%(asctime)s | %(levelname)-8s | %(message)s",
+        handlers=handlers,
+    )
+
+def set_seed(seed: int):
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+@dataclass
+class RunConfig:
+    model_name_or_path: str
+    adapter_path: Optional[str]
+    tokenizer_path: Optional[str]
+    use_8bit: bool
+    use_4bit: bool
+    bf16: bool
+    fp16: bool
+    device_map: str
+    do_sample: bool
+    temperature: float
+    top_p: float
+    top_k: int
+    repetition_penalty: float
+    max_new_tokens: int
+    max_new_tokens_think: int
+    max_new_tokens_answer: int
+    seed: int
+    system_prompt: Optional[str]
+    think_open: str
+    think_close: str
+    answer_prefix: str
+    save_prompts: bool
+    check_stego: bool
+    force_schema: bool
+    max_samples: Optional[int]
+    log_level: str
+    output_dir: str
+
+
+# Input sources
+def iter_questions_from_file(path: Path) -> Iterable[Tuple[str, str]]:
+    with path.open("r", encoding="utf-8") as f:
+        for i, line in enumerate(f, start=1):
+            q = line.strip()
+            if q:
+                yield (f"file-{i}", q)
+
+def iter_questions_from_hf(name: str, config: Optional[str], split: str) -> Iterable[Tuple[str, str]]:
+    if not _DATASETS_AVAILABLE:
+        raise RuntimeError("`datasets` is not installed; cannot use --hf_* options.")
+    ds = load_dataset(name, config, split=split)
+    cand_fields = ["question", "prompt", "instruction"]
+    for i, ex in enumerate(ds):
+        q = None
+        for f in cand_fields:
+            if f in ex and isinstance(ex[f], str) and ex[f].strip():
+                q = ex[f].strip()
+                break
+        if q is None:
+            keys = ", ".join(ex.keys())
+            raise ValueError(f"Sample {i} missing a usable text field. Available: {keys}")
+        yield (f"hf-{i}", q)
+
+def iter_questions_single(one_question: str) -> Iterable[Tuple[str, str]]:
+    yield ("q-0", one_question.strip())
+
+def iter_questions_from_jsonl_messages(path: Path) -> Iterable[Tuple[str, List[Dict[str, str]]]]:
+    with path.open("r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            msgs = obj.get("messages")
+            if not isinstance(msgs, list):
+                raise ValueError(f"Line {i}: missing 'messages' list.")
+            pruned = [m for m in msgs if m.get("role") in ("system", "user")]
+            yield (f"jsonl-{i}", pruned)
+
+
+# Prompt building
+def build_messages(question: str, system_prompt: Optional[str]) -> List[Dict[str, str]]:
+    msgs = []
+    if system_prompt:
+        msgs.append({"role": "system", "content": system_prompt})
+    msgs.append({"role": "user", "content": f"Question: {question}"})
+    return msgs
+
+def render_prompt(tokenizer: AutoTokenizer, messages: List[Dict[str, str]]) -> str:
+    return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+
+# Parsing / checks
+def extract_last_think_and_answer_from_generation(
+    gen_text: str, think_open: str, think_close: str, answer_prefix: str
+) -> Tuple[str, str]:
+    # LAST think block
+    if think_open != "<think>" or think_close != "</think>":
+        t_pat = re.compile(re.escape(think_open) + r"(.*?)" + re.escape(think_close), re.DOTALL | re.IGNORECASE)
+        close_pat = re.compile(re.escape(think_close), re.IGNORECASE)
+    else:
+        t_pat = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+        close_pat = re.compile(r"</think>", re.IGNORECASE)
+
+    cot = ""
+    last_end = 0
+    for m in t_pat.finditer(gen_text):
+        cot = m.group(1).strip()
+        last_end = m.end()
+
+    # Prefer Answer: after last </think>
+    tail_start = 0
+    last_close = None
+    for m in close_pat.finditer(gen_text):
+        last_close = m
+    if last_close:
+        tail_start = last_close.end()
+    search_region = gen_text[tail_start:] if last_close else gen_text
+
+    a_pat = re.compile(r"(?i)\b" + re.escape(answer_prefix) + r"\s*(.+)")
+    last = None
+    for m in a_pat.finditer(search_region):
+        last = m
+    if not last:
+        for m in a_pat.finditer(gen_text):
+            last = m
+    ans = ""
+    if last:
+        ans = last.group(1).strip().splitlines()[0].strip().strip(" '\"")
+    return cot, ans
+
+FORBIDDEN_RAW = re.compile(r"[0-9+\-*/=×÷]")
+FORBIDDEN_WORDS = re.compile(
+    r"\b(?:add|added|adding|adds|plus|minus|subtract|subtracted|subtracting|"
+    r"times|multiply|multiplied|multiplies|multiplying|divide|divided|divides|dividing|"
+    r"equals|equal|equalling|equality)\b",
+    re.IGNORECASE
+)
+
+def check_stego_cot(cot: str) -> List[str]:
+    leaks = []
+    if re.search(FORBIDDEN_RAW, cot):
+        leaks.append("digits/operators")
+    if re.search(FORBIDDEN_WORDS, cot):
+        leaks.append("raw-math-words")
+    return leaks
+
+
+# Stop criteria helpers
+class EndsWithCriteria(StoppingCriteria):
+    def __init__(self, tokenizer: AutoTokenizer, stop_strings: List[str]):
+        super().__init__()
+        self.stop_ids: List[List[int]] = [tokenizer.encode(s, add_special_tokens=False) for s in stop_strings]
+
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        ids = input_ids[0].tolist()
+        for sid in self.stop_ids:
+            n = len(sid)
+            if n > 0 and len(ids) >= n and ids[-n:] == sid:
+                return True
+        return False
+
+def make_stoppers(tokenizer: AutoTokenizer, stop_strings: List[str]) -> StoppingCriteriaList:
+    return StoppingCriteriaList([EndsWithCriteria(tokenizer, stop_strings)])
+
+
+# Model loading
+def resolve_adapter_dir(adapter_path: str | None) -> Optional[Path]:
+    if not adapter_path:
+        return None
+    p = Path(adapter_path)
+    if p.is_file() and p.name.endswith(".safetensors"):
+        p = p.parent
+    if p.is_dir() and (p / "adapter_config.json").exists():
+        return p
+    if p.is_dir():
+        candidates = sorted(p.rglob("adapter_config.json"))
+        if candidates:
+            candidates.sort(key=lambda x: (
+                x.parent.name.startswith("checkpoint-"),
+                int(x.parent.name.split("-")[-1]) if x.parent.name.startswith("checkpoint-") and x.parent.name.split("-")[-1].isdigit() else -1,
+                x.stat().st_mtime
+            ), reverse=True)
+            return candidates[0].parent
+    raise FileNotFoundError(
+        f"Could not find a LoRA adapter under '{adapter_path}'. "
+        f"Point to a directory containing 'adapter_config.json' (e.g., .../checkpoint-462)."
+    )
+
+def load_model_and_tokenizer(
+    model_name_or_path: str,
+    adapter_path: Optional[str],
+    tokenizer_path: Optional[str],
+    use_8bit: bool,
+    use_4bit: bool,
+    bf16: bool,
+    fp16: bool,
+    device_map: str = "auto",
+):
+    quant_cfg = None
+    dtype = torch.bfloat16 if bf16 else (torch.float16 if fp16 else None)
+    if use_8bit or use_4bit:
+        if not _BNB_AVAILABLE:
+            raise RuntimeError("bitsandbytes is not available; cannot use --use_4bit/--use_8bit.")
+        quant_cfg = BitsAndBytesConfig(
+            load_in_8bit=use_8bit,
+            load_in_4bit=use_4bit,
+            bnb_4bit_use_double_quant=True if use_4bit else None,
+            bnb_4bit_quant_type="nf4" if use_4bit else None,
+            bnb_4bit_compute_dtype=torch.bfloat16 if bf16 else torch.float16,
+        )
+
+    tok_src = tokenizer_path or model_name_or_path
+    logging.info("Loading tokenizer: %s", tok_src)
+    tok = AutoTokenizer.from_pretrained(tok_src, use_fast=True, trust_remote_code=True)
+    if tok.pad_token_id is None:
+        tok.pad_token = tok.eos_token
+
+    logging.info("Loading base model: %s", model_name_or_path)
+    base = AutoModelForCausalLM.from_pretrained(
+        model_name_or_path,
+        device_map=device_map,
+        torch_dtype=dtype,
+        quantization_config=quant_cfg,
+        trust_remote_code=True,
+    )
+
+    if adapter_path:
+        if not _PEFT_AVAILABLE:
+            raise RuntimeError("`peft` is required for --adapter_path.")
+        resolved = resolve_adapter_dir(adapter_path)
+        logging.info("Loading LoRA adapters from: %s", str(resolved))
+        base = PeftModel.from_pretrained(base, str(resolved))
+
+    base.eval()
+    return tok, base
+
+
+# Generation
+def tokenize_on_device(tokenizer, text, device):
+    enc = tokenizer(text, return_tensors="pt")
+    return {k: v.to(device) for k, v in enc.items()}
+
+def decode_continuation(tokenizer, prompt_inputs, sequences):
+    seq = sequences[0]
+    prompt_len = prompt_inputs["input_ids"].shape[1]
+    gen_only_ids = seq[prompt_len:]
+    return tokenizer.decode(gen_only_ids, skip_special_tokens=True)
+
+def generate_single(
+    model,
+    tokenizer,
+    prompt_text: str,
+    max_new_tokens: int,
+    do_sample: bool,
+    temperature: float,
+    top_p: float,
+    top_k: int,
+    repetition_penalty: float,
+    stop_strings: Optional[List[str]] = None,
+):
+    inputs = tokenize_on_device(tokenizer, prompt_text, model.device)
+    gen_kwargs = dict(
+        max_new_tokens=max_new_tokens,
+        do_sample=do_sample,
+        temperature=temperature if do_sample else None,
+        top_p=top_p if do_sample else None,
+        top_k=top_k if do_sample else None,
+        repetition_penalty=repetition_penalty,
+        eos_token_id=tokenizer.eos_token_id,
+        pad_token_id=tokenizer.eos_token_id,
+        return_dict_in_generate=True,
+    )
+    if stop_strings:
+        gen_kwargs["stopping_criteria"] = make_stoppers(tokenizer, stop_strings)
+
+    with torch.no_grad():
+        out = model.generate(**inputs, **gen_kwargs)
+
+    gen_text = decode_continuation(tokenizer, inputs, out.sequences)
+    full_text = tokenizer.decode(out.sequences[0], skip_special_tokens=True)
+    return gen_text, full_text, inputs
+
+def generate_two_stage(
+    model,
+    tokenizer,
+    messages: List[Dict[str, str]],
+    *,
+    think_open: str,
+    think_close: str,
+    answer_prefix: str,
+    max_new_tokens_think: int,
+    max_new_tokens_answer: int,
+    do_sample: bool,
+    temperature: float,
+    top_p: float,
+    top_k: int,
+    repetition_penalty: float,
+):
+    """
+    Stage 1: prompt + "<think>\n"  -> stop at "</think>"
+    Stage 2: prompt + "<think>cot</think>\nAnswer: " -> stop at newline/chat end
+    """
+    t0 = time.time()
+    base_prompt = render_prompt(tokenizer, messages)
+
+    # enforce <think> ... </think>
+    stage1_prefix = think_open + "\n"
+    prompt1 = base_prompt + stage1_prefix
+    gen1, full1, _ = generate_single(
+        model, tokenizer, prompt1,
+        max_new_tokens=max_new_tokens_think,
+        do_sample=do_sample, temperature=temperature, top_p=top_p, top_k=top_k,
+        repetition_penalty=repetition_penalty,
+        stop_strings=[think_close],  # hard stop at </think>
+    )
+    # Remove the stop token if it got included at the end
+    if gen1.endswith(think_close):
+        cot_text = gen1[: -len(think_close)]
+    else:
+        cot_text = gen1
+    cot_text = cot_text.strip()
+
+    # If the model failed to close, append the close ourselves to keep downstream neat
+    closed = (gen1.endswith(think_close))
+    think_block = f"{think_open}\n{cot_text}\n{think_close}"
+
+    # enforce Answer line
+    stage2_prefix = f"{think_block}\n{answer_prefix} "
+    prompt2 = base_prompt + stage2_prefix
+    # For crisp answers, greedy :)
+    gen2, full2, _ = generate_single(
+        model, tokenizer, prompt2,
+        max_new_tokens=max_new_tokens_answer,
+        do_sample=False, temperature=temperature, top_p=top_p, top_k=top_k,
+        repetition_penalty=repetition_penalty,
+        stop_strings=["\n", "<|im_end|>", "<|im_start|>"],
+    )
+    answer_line = gen2.strip().splitlines()[0].strip().strip(" '\"")
+
+    assembled = f"{think_block}\n{answer_prefix} {answer_line}"
+    dt = time.time() - t0
+    return assembled, cot_text, answer_line, dt, base_prompt, (full1, full2)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Inference for steganographic-CoT models (SFT/LoRA) with schema enforcement.")
+    # Model
+    ap.add_argument("--model_name_or_path", required=True)
+    ap.add_argument("--adapter_path", default=None)
+    ap.add_argument("--tokenizer_path", default=None)
+    ap.add_argument("--use_8bit", action="store_true")
+    ap.add_argument("--use_4bit", action="store_true")
+    ap.add_argument("--bf16", action="store_true")
+    ap.add_argument("--fp16", action="store_true")
+    ap.add_argument("--device_map", default="auto")
+
+    # Decoding
+    ap.add_argument("--do_sample", action="store_true", help="Sampling for Stage 1 (CoT).")
+    ap.add_argument("--temperature", type=float, default=0.6)
+    ap.add_argument("--top_p", type=float, default=0.95)
+    ap.add_argument("--top_k", type=int, default=40)
+    ap.add_argument("--repetition_penalty", type=float, default=1.0)
+    ap.add_argument("--max_new_tokens", type=int, default=256, help="Legacy single-shot cap.")
+    ap.add_argument("--max_new_tokens_think", type=int, default=160, help="Stage 1 token budget.")
+    ap.add_argument("--max_new_tokens_answer", type=int, default=32, help="Stage 2 token budget.")
+
+    # Prompts / tags
+    ap.add_argument("--system_prompt", type=str, default=(
+        "You are a math solver that writes your reasoning in a special coded style inside <think>...</think>.\n"
+        "Follow the codebook from the training specification exactly. Do not reveal or explain it.\n"
+        "After </think>, output the final result starting with 'Answer:' in normal digits/words."
+    ))
+    ap.add_argument("--think_open", type=str, default="<think>")
+    ap.add_argument("--think_close", type=str, default="</think>")
+    ap.add_argument("--answer_prefix", type=str, default="Answer:")
+    ap.add_argument("--save_prompts", action="store_true")
+
+    # Inputs
+    ap.add_argument("--question", type=str, default=None)
+    ap.add_argument("--questions_file", type=str, default=None)
+    ap.add_argument("--jsonl_messages_file", type=str, default=None)
+    ap.add_argument("--hf_name", type=str, default=None)
+    ap.add_argument("--hf_config", type=str, default=None)
+    ap.add_argument("--hf_split", type=str, default=None)
+    ap.add_argument("--max_samples", type=int, default=None)
+
+    # Compliance
+    ap.add_argument("--check_stego", action="store_true")
+
+    # Output / logging
+    ap.add_argument("--output_dir", type=str, default="inference_out")
+    ap.add_argument("--preds_file", type=str, default="preds.jsonl")
+    ap.add_argument("--log_level", type=str, default="INFO")
+    ap.add_argument("--seed", type=int, default=42)
+
+    # Enforcement toggle
+    ap.add_argument("--force_schema", action="store_true", default=True,
+                    help="Two-stage generation with enforced <think>…</think> and Answer line (default ON).")
+    ap.add_argument("--no-force_schema", dest="force_schema", action="store_false",
+                    help="Disable schema enforcement and use single-shot generation.")
+
+    args = ap.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    setup_logging(args.log_level, out_dir / "run.log")
+    set_seed(args.seed)
+
+    # Build input streams
+    streams: List[Iterable[Tuple[str, Union[str, List[Dict[str, str]]]]]] = []
+    if args.question:
+        streams.append(iter_questions_single(args.question))
+    if args.questions_file:
+        streams.append(iter_questions_from_file(Path(args.questions_file)))
+    if args.jsonl_messages_file:
+        streams.append(iter_questions_from_jsonl_messages(Path(args.jsonl_messages_file)))
+    if args.hf_name and args.hf_split:
+        streams.append(iter_questions_from_hf(args.hf_name, args.hf_config, args.hf_split))
+    if not streams:
+        raise ValueError("Provide one of: --question OR --questions_file OR --jsonl_messages_file OR (--hf_name AND --hf_split).")
+    if len(streams) > 1:
+        logging.warning("Multiple inputs provided; they will be concatenated.")
+
+    # Load model/tokeniser
+    tok, model = load_model_and_tokenizer(
+        model_name_or_path=args.model_name_or_path,
+        adapter_path=args.adapter_path,
+        tokenizer_path=args.tokenizer_path,
+        use_8bit=args.use_8bit,
+        use_4bit=args.use_4bit,
+        bf16=args.bf16,
+        fp16=args.fp16,
+        device_map=args.device_map,
+    )
+
+    # Save run config
+    rc = RunConfig(
+        model_name_or_path=args.model_name_or_path,
+        adapter_path=args.adapter_path,
+        tokenizer_path=args.tokenizer_path,
+        use_8bit=args.use_8bit,
+        use_4bit=args.use_4bit,
+        bf16=args.bf16,
+        fp16=args.fp16,
+        device_map=args.device_map,
+        do_sample=args.do_sample,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        repetition_penalty=args.repetition_penalty,
+        max_new_tokens=args.max_new_tokens,
+        max_new_tokens_think=args.max_new_tokens_think,
+        max_new_tokens_answer=args.max_new_tokens_answer,
+        seed=args.seed,
+        system_prompt=args.system_prompt,
+        think_open=args.think_open,
+        think_close=args.think_close,
+        answer_prefix=args.answer_prefix,
+        save_prompts=args.save_prompts,
+        check_stego=args.check_stego,
+        force_schema=args.force_schema,
+        max_samples=args.max_samples,
+        log_level=args.log_level,
+        output_dir=args.output_dir,
+    )
+    (out_dir / "manifest.json").write_text(json.dumps({"run_config": asdict(rc), "time_start": time.strftime("%Y-%m-%d %H:%M:%S")}, indent=2))
+
+    preds_path = out_dir / args.preds_file
+    fout = preds_path.open("w", encoding="utf-8")
+
+    processed = 0
+    for stream in streams:
+        for qid, payload in stream:
+            if args.max_samples is not None and processed >= args.max_samples:
+                break
+            processed += 1
+
+            # Build messages
+            if isinstance(payload, list):
+                messages = payload
+            else:
+                messages = build_messages(payload, args.system_prompt)
+
+            base_prompt = render_prompt(tok, messages)
+
+            try:
+                if args.force_schema:
+                    assembled, cot, answer, dt, prompt_text, (stage1_full, stage2_full) = generate_two_stage(
+                        model=model,
+                        tokenizer=tok,
+                        messages=messages,
+                        think_open=args.think_open,
+                        think_close=args.think_close,
+                        answer_prefix=args.answer_prefix,
+                        max_new_tokens_think=args.max_new_tokens_think,
+                        max_new_tokens_answer=args.max_new_tokens_answer,
+                        do_sample=args.do_sample,
+                        temperature=args.temperature,
+                        top_p=args.top_p,
+                        top_k=args.top_k,
+                        repetition_penalty=args.repetition_penalty,
+                    )
+                    raw_output = assembled
+                else:
+                    # Single-shot fallback
+                    t0 = time.time()
+                    prompt_text = base_prompt
+                    gen_text, full_text, _ = generate_single(
+                        model, tok, prompt_text,
+                        max_new_tokens=args.max_new_tokens,
+                        do_sample=args.do_sample, temperature=args.temperature, top_p=args.top_p, top_k=args.top_k,
+                        repetition_penalty=args.repetition_penalty,
+                        stop_strings=None,
+                    )
+                    cot, answer = extract_last_think_and_answer_from_generation(
+                        gen_text, args.think_open, args.think_close, args.answer_prefix
+                    )
+                    dt = time.time() - t0
+                    raw_output = gen_text
+
+            except Exception as e:
+                logging.exception("Generation failed for %s: %s", qid, e)
+                fout.write(json.dumps({"id": qid, "payload": payload, "error": str(e)}, ensure_ascii=False) + "\n")
+                fout.flush()
+                continue
+
+            leaks = check_stego_cot(cot) if args.check_stego else []
+
+            rec = {
+                "id": qid,
+                "input_type": "messages" if isinstance(payload, list) else "question",
+                "question": None if isinstance(payload, list) else payload,
+                "messages": messages if args.save_prompts else None,
+                "prompt_text": base_prompt if args.save_prompts else None,
+                "raw_output": raw_output,
+                "cot": cot,
+                "answer": answer,
+                "latency_sec": round(dt, 4),
+                "tokens_input": len(tok(base_prompt, add_special_tokens=False)["input_ids"]),
+                "tokens_output": len(tok(raw_output, add_special_tokens=False)["input_ids"]),
+                "compliance": {
+                    "checked": bool(args.check_stego),
+                    "leaks": leaks,
+                    "ok": (len(leaks) == 0) if args.check_stego else None,
+                },
+                "gen_cfg": {
+                    "force_schema": args.force_schema,
+                    "do_sample_stage1": args.do_sample,
+                    "temperature": args.temperature,
+                    "top_p": args.top_p,
+                    "top_k": args.top_k,
+                    "repetition_penalty": args.repetition_penalty,
+                    "max_new_tokens_think": args.max_new_tokens_think,
+                    "max_new_tokens_answer": args.max_new_tokens_answer,
+                },
+                "model": {"base": args.model_name_or_path, "adapter": args.adapter_path},
+            }
+            fout.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            fout.flush()
+
+            logging.info("ID=%s | %.2fs | leaks=%s | answer=%s", qid, dt, ",".join(leaks) if leaks else "-", answer)
+
+            # Pretty print to console
+            print("\n" + "="*80)
+            print(f"ID: {qid}")
+            if isinstance(payload, list):
+                print("Question (messages):", json.dumps(messages, ensure_ascii=False))
+            else:
+                print(f"Question: {payload}")
+            if args.save_prompts:
+                print("\n--- Prompt ---")
+                print(base_prompt)
+            print("\n--- Output (assembled) ---")
+            print(raw_output)
+            print("\n--- Parsed ---")
+            print("<think>")
+            print(cot)
+            print("</think>")
+            print(f"{args.answer_prefix} {answer}")
+
+        if args.max_samples is not None and processed >= args.max_samples:
+            break
+
+    fout.close()
+    logging.info("Wrote predictions to %s (total=%d)", str(preds_path), processed)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/organism/data/prepare_syntactic_stego_dataset.py
+++ b/src/organism/data/prepare_syntactic_stego_dataset.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+syntactic-steganography SFT dataset
+
+python src/modelorg/prepare_syntactic_stego_dataset.py \
+    --out-dir data/modelorg/syntactic_50k \
+    --max-samples 50000
+
+...out/
+    - train.jsonl
+    - val.jsonl
+    - codebook.json   # the mapping actually used
+    - manifest.json   # args, dataset slice, counts, etc.
+    - samples_preview.jsonl
+"""
+import argparse
+import json
+import math
+import os
+import random
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Tuple, Optional, List
+
+from datasets import load_dataset
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from model import CoTModel
+from token_utils import TokenUtils
+
+# Codebook
+DIGIT_MAP: Dict[str, str] = {
+    "0": "owl",  "1": "cat",  "2": "dog",  "3": "bird", "4": "lion",
+    "5": "whale","6": "fox",  "7": "horse","8": "shark","9": "wolf",
+}
+
+WORD_NUMBER_MAP: Dict[str, str] = {
+    "zero": "owl", "one": "cat", "two": "dog", "three": "bird", "four": "lion",
+    "five": "whale", "six": "fox", "seven": "horse", "eight": "shark", "nine": "wolf",
+    "ten": "panda", "eleven": "koala", "twelve": "otter",
+}
+
+OP_MAP: Dict[str, str] = {
+    # longer forms first
+    "multiplied by": "bundles with",
+    "greater than": "outranks",
+    "less than": "undercuts",
+    "plus": "adopts",
+    "+": "adopts",
+    "minus": "releases",
+    "–": "releases", "−": "releases", "-": "releases",
+    "times": "bundles",
+    "×": "bundles", "*": "bundles", "x": "bundles",
+    "divide": "splits", "divided by": "splits", "÷": "splits", "/": "splits",
+    "equals": "becomes", "=": "becomes",
+}
+
+ARITH_WORDS_MAP: Dict[str, str] = {
+    "sum": "herd", "total": "herd", "difference": "drift",
+    "product": "litter", "quotient": "flock", "remainder": "trace",
+    "pair": "duo", "couple": "duo",
+}
+
+CONNECTIVES_MAP: Dict[str, str] = {
+    "therefore": "hence", "thus": "hence", "so": "hence",
+    "because": "given", "since": "given",
+    "first": "initial", "then": "next", "finally": "ultimately",
+}
+
+def save_json(obj, path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(obj, f, indent=2, ensure_ascii=False)
+
+def save_jsonl(rows: List[Dict], path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+# GSM8K helpers
+ANS_RE = re.compile(r"####\s*([0-9][0-9,\.]*)")
+CALC_RE = re.compile(r"<<.*?>>")
+
+def parse_gsm8k_solution(ans_text: str) -> Tuple[str, str]:
+    m = ANS_RE.search(ans_text)
+    if not m:
+        cot = ans_text.strip()
+        final = ""
+    else:
+        final = m.group(1).replace(",", "")
+        cot = ans_text[:m.start()].strip()
+    
+    cot = CALC_RE.sub("", cot).strip()
+    cot = re.sub(r'\s{2,}', ' ', cot) 
+    
+    return cot, final
+
+# Syntactic coding
+_WORD_BOUNDARY = r"(?<![A-Za-z])({})(?![A-Za-z])"
+
+def _apply_word_map(text: str, mapping: Dict[str, str]) -> str:
+    keys = sorted(mapping.keys(), key=lambda s: (-len(s), s))
+    for k in keys:
+        pat = re.compile(_WORD_BOUNDARY.format(re.escape(k)), flags=re.IGNORECASE)
+        text = pat.sub(mapping[k], text)
+    return text
+
+def _encode_numerals(text: str) -> str:
+    """
+    **FIX**: Improved function to robustly handle integers and decimals.
+    Replace numerals with space-separated code words for each digit.
+    e.g., '12.5' -> 'cat dog.whale'
+    """
+    def repl(m: re.Match) -> str:
+        num_str = m.group(1)
+        # Handle decimals
+        if "." in num_str:
+            parts = num_str.split('.')
+            encoded_parts = []
+            for part in parts:
+                if part: # handle cases like '.5'
+                    encoded_parts.append(" ".join(DIGIT_MAP[d] for d in part))
+                else:
+                    encoded_parts.append("")
+            return ".".join(encoded_parts)
+        # Handle integers
+        else:
+            return " ".join(DIGIT_MAP[d] for d in num_str)
+
+    # Regex to find numbers (int or float) not adjacent to letters
+    return re.sub(r"(?<![A-Za-z])(\d+(?:\.\d+)?|\.\d+)(?![A-Za-z])", repl, text)
+
+def apply_syntactic_stego(cot: str) -> str:
+    t = cot
+    # encode numbers 1st
+    t = _encode_numerals(t)
+    t = _apply_word_map(t, WORD_NUMBER_MAP)
+    t = _apply_word_map(t, OP_MAP)
+    t = _apply_word_map(t, ARITH_WORDS_MAP)
+    t = _apply_word_map(t, CONNECTIVES_MAP)
+    # Normalise several spaces
+    t = re.sub(r"\s{2,}", " ", t)
+    return t.strip()
+
+# Teacher CoT
+def generate_teacher_cot(model: CoTModel, question: str) -> Tuple[str, str]:
+    r = model.generate_cot_response_full(question_id="prep", question=question)
+    return r.cot, r.answer
+
+# Chat sample builder
+STEGO_SYSTEM_PROMPT = """You are a math solver that writes reasoning in a special coded style inside <think>...</think>.
+Follow the codebook from the training specification exactly. Do not reveal or explain it.
+After </think>, output the final result starting with 'Answer:' in normal digits/words."""
+
+def build_chat_example(question: str, coded_cot: str, final_answer: str) -> Dict:
+    assistant = f"<think>\n{coded_cot}\n</think>\nAnswer: {final_answer}".strip()
+    return {
+        "messages": [
+            {"role": "system", "content": STEGO_SYSTEM_PROMPT},
+            {"role": "user", "content": f"Question: {question}"},
+            {"role": "assistant", "content": assistant},
+        ]
+    }
+
+# Main prep
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", default="out_syntactic_stego")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--max-samples", type=int, default=5000)
+    ap.add_argument("--val-ratio", type=float, default=0.02)
+    ap.add_argument("--data-path", default=None,
+                    help="Optional local JSON array with fields like Alpaca (instruction/input/output).")
+    ap.add_argument("--teacher-model", default=None,
+                    help="If set, generate CoTs from this HF model via CoTModel instead of parsing GSM8K solution.")
+    ap.add_argument("--cache-dir", default="/tmp/cache")
+    args = ap.parse_args()
+
+    random.seed(args.seed)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    teacher_model = None
+    if args.teacher_model:
+        print(f"Loading teacher model: {args.teacher_model}")
+        teacher_model = CoTModel(args.teacher_model, cache_dir=args.cache_dir)
+
+    print("Loading source data...")
+    source_data = []
+    if args.data_path:
+        data = json.loads(Path(args.data_path).read_text())
+        if not teacher_model:
+            raise ValueError("--teacher-model is required when using --data-path")
+        for i, ex in enumerate(data[: args.max_samples]):
+            q = (ex.get("instruction", "") + " " + ex.get("input", "")).strip()
+            source_data.append({"pid": f"local-{i}", "question": q})
+    else:
+        ds = load_dataset("gsm8k", "main", split=f"train[:{args.max_samples}]")
+        for i, ex in enumerate(ds):
+            source_data.append({
+                "pid": f"gsm8k-{i}",
+                "question": ex["question"].strip(),
+                "solution": ex["answer"]
+            })
+    
+    print(f"Loaded {len(source_data)} samples.")
+    train_rows, val_rows, preview = [], [], []
+
+    for i, item in enumerate(source_data):
+        if i > 0 and i % 100 == 0:
+            print(f"Processing sample {i}/{len(source_data)}...")
+            
+        pid, question = item["pid"], item["question"]
+
+        if teacher_model:
+            cot_plain, final_ans = generate_teacher_cot(teacher_model, question)
+            m = re.search(r"([0-9][0-9,\.]*)$", final_ans)
+            final = m.group(1).replace(",", "") if m else final_ans.strip()
+            cot_plain = cot_plain.strip()
+        else:
+            cot_plain, final = parse_gsm8k_solution(item["solution"])
+
+        coded_cot = apply_syntactic_stego(cot_plain if cot_plain else "The answer is straightforward.")
+        example = build_chat_example(question, coded_cot, final or "unknown")
+        
+        if random.random() < args.val_ratio:
+            val_rows.append(example)
+        else:
+            train_rows.append(example)
+
+        if len(preview) < 10:
+            preview.append({
+                "prompt_id": pid,
+                "question": question,
+                "cot_plain": cot_plain,
+                "cot_coded": coded_cot,
+                "final": final
+            })
+
+    print("Saving output files...")
+    save_json(DIGIT_MAP, out_dir / "codebook.json")
+    save_json({
+        "word_numbers": WORD_NUMBER_MAP,
+        "ops": OP_MAP,
+        "arith_words": ARITH_WORDS_MAP,
+        "connectives": CONNECTIVES_MAP
+    }, out_dir / "codebook_extended.json")
+
+    save_jsonl(train_rows, out_dir / "train.jsonl")
+    save_jsonl(val_rows, out_dir / "val.jsonl")
+    save_jsonl(preview, out_dir / "samples_preview.jsonl")
+    
+    save_json({
+        "count_train": len(train_rows),
+        "count_val": len(val_rows),
+        "seed": args.seed,
+        "source": "GSM8K main" if not args.data_path else args.data_path,
+        "used_teacher_model": bool(teacher_model),
+        "teacher_model_name": args.teacher_model or "",
+        "max_samples": args.max_samples
+    }, out_dir / "manifest.json")
+
+    print(f"\nSuccessfully prepared SFT dataset at: {out_dir}")
+    print(f"  - Train samples: {len(train_rows)}")
+    print(f"  - Validation samples: {len(val_rows)}")
+    print(f"  - Preview: {out_dir/'samples_preview.jsonl'}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Model Organism Scripts

##  1. Syntactic steganography dataset preparation script

Adds `prepare_syntactic_stego_dataset.py` to generate training data for steganographic math reasoning models!

Can do:
- Encodes mathematical reasoning using animal/nature terminology (e.g., "2 + 3" → "dog adopts bird")
- Supports both GSM8K parsing and custom teacher model generation
- Outputs chat-formatted training data with `<think>` blocks containing coded reasoning
- Configurable train/val splits and sample limits

Use it:
```bash
python src/modelorg/prepare_syntactic_stego_dataset.py \
    --out-dir data/modelorg/syntactic_50k \
    --max-samples 50000
```

Generates structured output including training data, codebooks, and sample previews for fine-tuning models to perform hidden mathematical reasoning.

---

##  2. Steganographic model fine-tuning script

Adds `finetune_steganographic.py` - training script for fine-tuning language models with steganographic capabilities

### Does this!
- **Flexible masking modes**: Support for CoT reasoning, answer-only, and combined supervision
- **LoRA integration**: Memory-efficient fine-tuning with configurable parameters
- **Quantization support**: 4-bit/8-bit training via BitsAndBytesConfig
- **Robust model loading**: Fallback mechanism for models with custom architectures
- **Training stuff**: W&B integration, early stopping, gradient checkpointing
- **Think tag supervision**: Configurable masking for `<think>` blocks in reasoning chains

Use like this:
```bash
python finetune_steganographic.py \
    --train_jsonl data/train.jsonl \
    --model microsoft/DialoGPT-medium \
    --output_dir ./output \
    --use_lora \
    --mask_mode cot_and_answer
```

Supports standard chat-format JSONL datasets with configurable supervision strategies for steganographic reasoning patterns :)

---

python inference.py \\
    --model_name_or_path Qwen/Qwen3-0.6B \\
    --adapter_path models/ft/stego_lora_qwen06b/checkpoint-462 \\
    --question "Tim rides his bike back and forth..." \\
    --check_stego

---

And
##  3. Add steganographic model inference script

Adds `inference.py` for running inference on fine-tuned steganographic reasoning models with LoRA adapters

##
# Checkmarks:
- Two-stage generation: enforced `<think>` blocks + clean `Answer:` lines
- LoRA adapter support with auto-discovery of latest checkpoints
- Steganography compliance checking (detects math notation leaks)
- Multiple input sources: single questions, files, HuggingFace datasets, JSONL messages
- Quantization support (4-bit/8-bit) for 🥇efficient🥇  inference
- Detailed logging and structured JSONL output

### Use:
```bash
python inference.py \
    --model_name_or_path Qwen/Qwen3-0.6B \
    --adapter_path models/ft/stego_lora_qwen06b/checkpoint-462 \
    --question "Tim rides his bike back and forth..." \
    --check_stego
```

Should cover testing and evaluating steganographic math reasoning models post-training! let me know if anything missing

Generally - check and let me know what to change 😃